### PR TITLE
Remove duplicated entry in contributors.ts

### DIFF
--- a/app/data/contributors.ts
+++ b/app/data/contributors.ts
@@ -436,11 +436,6 @@ export const contributors: ContributorsProps[] = [
     url: 'https://github.com/rts-kotori',
   },
   {
-    name: 'pokyunni',
-    avatar_url: 'https://avatars.githubusercontent.com/u/16944731?v=4',
-    url: 'https://github.com/pokyunn',
-  },
-  {
     name: 'atajsic',
     avatar_url: 'https://avatars.githubusercontent.com/u/570505?v=4',
     url: 'https://github.com/atajsic',


### PR DESCRIPTION
My account had two entries, lines L438-L443 and L458-L462, removing the one with typo in name

<img width="590" height="233" alt="image" src="https://github.com/user-attachments/assets/9109b49d-0644-4c6e-a602-4d55f31f0c83" />
